### PR TITLE
최근 접속시간 기록 Interceptor 설정

### DIFF
--- a/src/main/kotlin/mashup/backend/tdtd/config/WebConfig.kt
+++ b/src/main/kotlin/mashup/backend/tdtd/config/WebConfig.kt
@@ -1,9 +1,6 @@
 package mashup.backend.tdtd.config
 
-import mashup.backend.tdtd.config.interceptor.AuthenticationHostInterceptor
-import mashup.backend.tdtd.config.interceptor.DeviceIdInterceptor
-import mashup.backend.tdtd.config.interceptor.RedirectionHomeInterceptor
-import mashup.backend.tdtd.config.interceptor.UserRegistrationInterceptor
+import mashup.backend.tdtd.config.interceptor.*
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
@@ -13,7 +10,8 @@ class WebConfig(
     private val deviceIdInterceptor: DeviceIdInterceptor,
     private val userRegistrationInterceptor: UserRegistrationInterceptor,
     private val authenticationHostInterceptor: AuthenticationHostInterceptor,
-    private val redirectionHomeInterceptor: RedirectionHomeInterceptor
+    private val redirectionHomeInterceptor: RedirectionHomeInterceptor,
+    private val recentAccessInterceptor: RecentAccessInterceptor
 ) : WebMvcConfigurer {
     companion object {
         const val ALL_PATH = "/**"
@@ -38,6 +36,8 @@ class WebConfig(
             .addPathPatterns(USER_REGISTRATION_URL_PATH).order(1)
         registry.addInterceptor(authenticationHostInterceptor)
             .addPathPatterns(HOST_ONLY_URL_PATH).order(1)
+        registry.addInterceptor(recentAccessInterceptor)
+            .addPathPatterns(ALL_API_PATH).order(2)
         super.addInterceptors(registry)
     }
 }

--- a/src/main/kotlin/mashup/backend/tdtd/config/interceptor/RecentAccessInterceptor.kt
+++ b/src/main/kotlin/mashup/backend/tdtd/config/interceptor/RecentAccessInterceptor.kt
@@ -1,0 +1,22 @@
+package mashup.backend.tdtd.config.interceptor
+
+import mashup.backend.tdtd.user.service.UserService
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+class RecentAccessInterceptor(
+    private val userService: UserService
+) : HandlerInterceptor {
+    companion object {
+        const val DEVICE_ID_KEY_IN_HEADER = "Device-Id"
+    }
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        val deviceId: String = request.getHeader(DEVICE_ID_KEY_IN_HEADER)
+        userService.updateUserLastUsedAt(deviceId)
+        return true
+    }
+}

--- a/src/main/kotlin/mashup/backend/tdtd/user/entity/User.kt
+++ b/src/main/kotlin/mashup/backend/tdtd/user/entity/User.kt
@@ -1,6 +1,7 @@
 package mashup.backend.tdtd.user.entity
 
 import mashup.backend.tdtd.common.entity.BaseEntity
+import java.time.LocalDateTime
 import javax.persistence.*
 
 @Table(name = "users")
@@ -23,5 +24,13 @@ class User(
     var userName: String? = null,
 
     @Column
-    var profile: String? = null
-) : BaseEntity()
+    var profile: String? = null,
+
+    @Column
+    var lastUsedAt: LocalDateTime? = LocalDateTime.now()
+) : BaseEntity() {
+
+    fun updateLastUsedAt() {
+        this.lastUsedAt = LocalDateTime.now()
+    }
+}

--- a/src/main/kotlin/mashup/backend/tdtd/user/entity/User.kt
+++ b/src/main/kotlin/mashup/backend/tdtd/user/entity/User.kt
@@ -26,8 +26,8 @@ class User(
     @Column
     var profile: String? = null,
 
-    @Column
-    var lastUsedAt: LocalDateTime? = LocalDateTime.now()
+    @Column(columnDefinition = "DATETIME")
+    var lastUsedAt: LocalDateTime = LocalDateTime.now()
 ) : BaseEntity() {
 
     fun updateLastUsedAt() {

--- a/src/main/kotlin/mashup/backend/tdtd/user/service/UserService.kt
+++ b/src/main/kotlin/mashup/backend/tdtd/user/service/UserService.kt
@@ -5,6 +5,7 @@ import mashup.backend.tdtd.common.exception.NotFoundException
 import mashup.backend.tdtd.user.entity.User
 import mashup.backend.tdtd.user.repository.UserRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class UserService(private val userRepository: UserRepository) {
@@ -23,4 +24,10 @@ class UserService(private val userRepository: UserRepository) {
 
     fun createUser(deviceId: String, userName: String): User =
         userRepository.save(User(deviceId = deviceId, userName = userName))
+
+    @Transactional
+    fun updateUserLastUsedAt(deviceId: String) {
+        val user: User = getUserByDeviceId(deviceId)
+        user.updateLastUsedAt()
+    }
 }


### PR DESCRIPTION
## [ #30 ] 최근 접속시간 기록 Interceptor 설정

모든 API 호출 시 사용자의 최근 접속시간을 업데이트

## 🔎 작업 내용

- 사용자 엔티티에 `lastUsedAt` 프로퍼티 추가
- 최근 접속시간을 업데이트하는 Interceptor 추가
- Test DB에 컬럼 추가
- PR 완료 후, Real DB에 컬럼 추가 예정

## ⚖ Test 결과
> 테스트 코드나 swagger를 통한 테스트 결과를 선택하세요

- [x] 성공한 결과를 확인했어요! 😍
- [ ] 테스트를 하지 못(안)했어요... 😭
- [ ] 실패한 결과를 확인했어요;; 😱
